### PR TITLE
Added possibility to use your own custom marker

### DIFF
--- a/demo/map.php
+++ b/demo/map.php
@@ -21,6 +21,11 @@ function test_register_meta_boxes()
 				'std'           => '-6.233406,-35.049906,15',     // 'latitude,longitude[,zoom]' (zoom is optional)
 				'style'         => 'width: 500px; height: 500px',
 				'address_field' => 'address',                     // Name of text field where address is entered. Can be list of text fields, separated by commas (for ex. city, state)
+				'marker'      		 => true, 					  // Display marker? Default is 'true',
+			    'marker_settings'	 => array(					  // Use your own marker for maps
+			    	'url'	=> 'http://openclipart.org/image/800px/svg_to_png/168985/map-marker-23x31-active.png', // Give an image with the map
+			    	'size'	=> '40,60'							  // Don't forget the size
+			    	),
 			),
 		),
 	);

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -353,13 +353,47 @@ if ( ! class_exists( 'RWMB_Helper' ) )
 
 			if ( $args['marker'] )
 			{
-				$html .= sprintf( '
-					var marker = new google.maps.Marker( {
-						position: center,
-						map: map%s
-					} );',
-					$args['marker_title'] ? ', title: "' . $args['marker_title'] . '"' : ''
-				);
+				if ( $args['marker_settings'] ){
+					$settings = $args['marker_settings'];
+
+					// checking if url and size is not empty
+					if (empty($settings['url']) || empty($settings['size']))
+						return '<p>Please give an image and a size</p>';
+
+					// checking if url is an image
+					if (!getimagesize($settings['url']))
+						return '<p>This is not an image</p>';
+
+					// check if size has a comma
+					if (strpos(',', $settings['size']) !== false)
+						return '<p>The given size is not correct. Example: 50,50</p>';
+
+					// defining the marker for the map
+					$html .= sprintf('
+						var image = new google.maps.MarkerImage(
+							"' . $settings['url'] . '",
+							null, /* size is determined at runtime */
+    						null, /* origin is 0,0 */
+   							null, /* anchor is bottom center of the scaled image */
+    						new google.maps.Size(' . $settings['size'] . ')
+						);
+						var marker = new google.maps.Marker( {
+							position: center,
+							map: map%s,
+							icon: image
+						} );',
+						$args['marker_title'] ? ', title: "' . $args['marker_title'] . '"' : ''
+					);
+				} else {
+					// if no marker is specified
+					$html .= sprintf( '
+						var marker = new google.maps.Marker( {
+							position: center,
+							map: map%s,
+						} );',
+						$args['marker_title'] ? ', title: "' . $args['marker_title'] . '"' : ''
+					);
+				}
 
 				if ( $args['info_window'] )
 				{

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -356,9 +356,15 @@ if ( ! class_exists( 'RWMB_Helper' ) )
 				if ( $args['marker_settings'] ){
 					$settings = $args['marker_settings'];
 
-					// checking if url and size is not empty
-					if (empty($settings['url']) || empty($settings['size']))
-						return '<p>Please give an image and a size</p>';
+					// checking if url is not empty
+					if (empty($settings['url']))
+						return '<p>Please give an image</p>';
+
+					// checking if size is not empty
+					if (empty($settings['size'])) {
+						list($width, $height) = getimagesize($settings['url']);
+						$settings['size'] = $width . ',' . $height;
+					}
 
 					// checking if url is an image
 					if (!getimagesize($settings['url']))


### PR DESCRIPTION
I needed a custom marker on my map, so I figured out how I could do this easily and with the possibility to distribute this functionality.

I added an extra argument to the google map: marker_settings
This argument is then passed through a series of checks to see if it is correctly filled in.
After the checks, I add the given image url to the map.