### PR TITLE
fixed path to loader.gif for plupload-image

### DIFF
--- a/js/plupload-image.js
+++ b/js/plupload-image.js
@@ -136,6 +136,6 @@ jQuery( function ( $ )
 	 */
 	function addThrobber( file )
 	{
-		$( '#' + file.id + '-throbber' ).html( '<img class="rwmb-loader" height="64" width="64" src="' + RWMB.url + '"img/loader.gif">' );
+		$( '#' + file.id + '-throbber' ).html( '<img class="rwmb-loader" height="64" width="64" src="' + RWMB.url + 'img/loader.gif">' );
 	}
 } );


### PR DESCRIPTION
Exited early due to an extra double quote after RWMB.url concatenation.