### PR TITLE
Added ability to use AJAX reponse instead of predefined options in Autocomplete Field

### DIFF
--- a/inc/fields/autocomplete.php
+++ b/inc/fields/autocomplete.php
@@ -31,13 +31,21 @@ if ( ! class_exists( 'RWMB_Autocomplete_Field' ) )
 			if ( ! is_array( $meta ) )
 				$meta = array( $meta );
 
-			$options = array();
-			foreach ( $field['options'] as $value => $label )
+			if( is_string( $field['options'] ) ) 
 			{
-				$options[] = array(
-					'value' => $value,
-					'label' => $label,
-				);
+				$options = $field['options'];
+			} 
+			else 
+			{
+				$options = array();
+				foreach ( $field['options'] as $value => $label )
+				{
+					$options[] = array(
+						'value' => $value,
+						'label' => $label,
+					);
+				}
+				$options = json_encode( $options );
 			}
 
 			// Input field that triggers autocomplete.
@@ -47,7 +55,7 @@ if ( ! class_exists( 'RWMB_Autocomplete_Field' ) )
 				'<input type="text" class="rwmb-autocomplete" id="%s" data-name="%s" data-options="%s" size="%s">',
 				$field['id'],
 				$field['field_name'],
-				esc_attr( json_encode( $options ) ),
+				esc_attr( $options ),
 				$field['size']
 			);
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -452,120 +452,129 @@ if ( ! class_exists( 'RWMB_Helper' ) )
 	RWMB_Helper::on_load();
 }
 
-/**
- * Get post meta
- *
- * @param string   $key     Meta key. Required.
- * @param int|null $post_id Post ID. null for current post. Optional
- * @param array    $args    Array of arguments. Optional.
- *
- * @return mixed
- */
-function rwmb_meta( $key, $args = array(), $post_id = null )
+if( ! function_exists( 'rwmb_meta' ) ) 
 {
-	return RWMB_Helper::meta( $key, $args, $post_id );
+  /**
+   * Get post meta
+   *
+   * @param string   $key     Meta key. Required.
+   * @param int|null $post_id Post ID. null for current post. Optional
+   * @param array    $args    Array of arguments. Optional.
+   *
+   * @return mixed
+   */
+  function rwmb_meta( $key, $args = array(), $post_id = null )
+  {
+  	return RWMB_Helper::meta( $key, $args, $post_id );
+  }
 }
 
-/**
- * Get value of custom field.
- * This is used to replace old version of rwmb_meta key.
- *
- * @param  string   $key     Meta key. Required.
- * @param  int|null $post_id Post ID. null for current post. Optional.
- * @return mixed             false if field doesn't exist. Field value otherwise.
- */
-function rwmb_get_field( $key, $post_id = null )
+if( ! function_exists( 'rwmb_get_field' ) ) 
 {
-	$field = RWMB_Helper::find_field( $key );
+  /**
+   * Get value of custom field.
+   * This is used to replace old version of rwmb_meta key.
+   *
+   * @param  string   $key     Meta key. Required.
+   * @param  int|null $post_id Post ID. null for current post. Optional.
+   * @return mixed             false if field doesn't exist. Field value otherwise.
+   */
+  function rwmb_get_field( $key, $post_id = null )
+  {
+  	$field = RWMB_Helper::find_field( $key );
 
-	// Get field value
-	return $field ? RWMB_Helper::meta( $key, $field, $post_id ) : false;
+  	// Get field value
+  	return $field ? RWMB_Helper::meta( $key, $field, $post_id ) : false;
+  }
 }
 
-/**
- * Display the value of a field
- *
- * @param  string   $key     Meta key. Required.
- * @param  int|null $post_id Post ID. null for current post. Optional.
- * @param  bool     $echo    Display field meta value? Default `true` which works in almost all cases. We use `false` for the [rwmb_meta] shortcode
- *
- * @return string
- */
-function rwmb_the_field( $key, $post_id = null, $echo = true )
+if( ! function_exists( 'rwmb_the_field' ) ) 
 {
-	// Find field
-	$field = RWMB_Helper::find_field( $key );
-	if ( ! $field )
-		return;
+  /**
+   * Display the value of a field
+   *
+   * @param  string   $key     Meta key. Required.
+   * @param  int|null $post_id Post ID. null for current post. Optional.
+   * @param  bool     $echo    Display field meta value? Default `true` which works in almost all cases. We use `false` for the [rwmb_meta] shortcode
+   *
+   * @return string
+   */
+  function rwmb_the_field( $key, $post_id = null, $echo = true )
+  {
+  	// Find field
+  	$field = RWMB_Helper::find_field( $key );
+  	if ( ! $field )
+  		return;
 
-	// Get field meta value
-	$meta = RWMB_Helper::meta( $key, $field, $post_id );
-	if ( empty( $meta ) )
-		return;
+  	// Get field meta value
+  	$meta = RWMB_Helper::meta( $key, $field, $post_id );
+  	if ( empty( $meta ) )
+  		return;
 
-	// Default output is meta value
-	$output = $meta;
+  	// Default output is meta value
+  	$output = $meta;
 
-	switch ( $field['type'] )
-	{
-		case 'checkbox':
-			$output = $field['name'];
-			break;
-		case 'radio':
-			$output = $field['options'][$meta];
-			break;
-		case 'file':
-		case 'file_advanced':
-			$output = '<ul>';
-			foreach ( $meta as $file )
-			{
-				$output .= sprintf(
-					'<li><a href="%s" title="%s">%s</a></li>',
-					$file['url'],
-					$file['title'],
-					$file['name']
-				);
-			}
-			$output .= '</ul>';
-			break;
-		case 'image':
-		case 'plupload_image':
-		case 'thickbox_image':
-		case 'image_advanced':
-			$output = '<ul>';
-			foreach ( $meta as $image )
-			{
-				$output .= sprintf(
-					'<li><img src="%s" alt="%s" title="%s" /></li>',
-					$image['url'],
-					$image['alt'],
-					$image['title']
-				);
-			}
-			$output .= '</ul>';
-			break;
-		case 'taxonomy':
-			$output = '<ul>';
-			foreach ( $meta as $term )
-			{
-				$output .= sprintf(
-					'<li><a href="%s" title="%s">%s</a></li>',
-					get_term_link( $term, $field['taxonomy'] ),
-					$term->name,
-					$term->name
-				);
-			}
-			$output .= '</ul>';
-			break;
-		default:
-			if ( is_array( $meta ) )
-			{
-				$output = '<ul><li>' . implode( '</li><li>', $meta ) . '</li></ul>';
-			}
-	}
+  	switch ( $field['type'] )
+  	{
+  		case 'checkbox':
+  			$output = $field['name'];
+  			break;
+  		case 'radio':
+  			$output = $field['options'][$meta];
+  			break;
+  		case 'file':
+  		case 'file_advanced':
+  			$output = '<ul>';
+  			foreach ( $meta as $file )
+  			{
+  				$output .= sprintf(
+  					'<li><a href="%s" title="%s">%s</a></li>',
+  					$file['url'],
+  					$file['title'],
+  					$file['name']
+  				);
+  			}
+  			$output .= '</ul>';
+  			break;
+  		case 'image':
+  		case 'plupload_image':
+  		case 'thickbox_image':
+  		case 'image_advanced':
+  			$output = '<ul>';
+  			foreach ( $meta as $image )
+  			{
+  				$output .= sprintf(
+  					'<li><img src="%s" alt="%s" title="%s" /></li>',
+  					$image['url'],
+  					$image['alt'],
+  					$image['title']
+  				);
+  			}
+  			$output .= '</ul>';
+  			break;
+  		case 'taxonomy':
+  			$output = '<ul>';
+  			foreach ( $meta as $term )
+  			{
+  				$output .= sprintf(
+  					'<li><a href="%s" title="%s">%s</a></li>',
+  					get_term_link( $term, $field['taxonomy'] ),
+  					$term->name,
+  					$term->name
+  				);
+  			}
+  			$output .= '</ul>';
+  			break;
+  		default:
+  			if ( is_array( $meta ) )
+  			{
+  				$output = '<ul><li>' . implode( '</li><li>', $meta ) . '</li></ul>';
+  			}
+  	}
 
-	if ( $echo )
-		echo $output;
+  	if ( $echo )
+  		echo $output;
 
-	return $output;
+  	return $output;
+  }
 }

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -36,7 +36,7 @@ jQuery( function ( $ )
 			{
 				$result.append(
 					'<div class="rwmb-autocomplete-result">' +
-					'<div class="label">' + ui.item.label + '</div>' +
+					'<div class="label">' + ( typeof ui.item.excerpt !== 'undefined' ? ui.item.excerpt : ui.item.label ) + '</div>' +
 					'<div class="actions">' + RWMB_Autocomplete.delete + '</div>' +
 					'<input type="hidden" class="rwmb-autocomplete-value" name="' + name + '" value="' + ui.item.value + '">' +
 					'</div>'


### PR DESCRIPTION
* Improved autocomplete field: added ability to use URL resource to return JSON data instead of predefined options; 
* Improved autocomplete field: added ability to show excerpt instead of label for selected option.
* Added condition function_exists to prevent potential issue with redeclaration of functions in inc/helpers.php

Usage Example:
```php
// Field declaration
array(
    'name' => 'Some Field',
    'id' => 'some_field',
    'type' => 'autocomplete',
    'options' => admin_url( 'admin-ajax.php?action=some_field' ),
)

// Backend
add_action( 'wp_ajax_some_field', function(){
   $s = $_REQUEST[ 'term' ];
   // Do some stuff here to find matches.

  // Example of excerption in response which is shown for selected option instead of label.
  $response = array(
      array( 'value' => '123', 'label' => 'Some Post', 'excerpt' => '<a href="http://example.com">Some Post</a>' ),
      array( 'value' => '77', 'label' => 'Another Post', 'excerpt' => '<a href="http://example.com">Another Post</a>' )
  );
  
 // Do some stuff to prepare JSON response ( headers, etc ).
  wp_json_encode( $response );
  die;

} );
```