### PR TITLE
Add escaping for text field values

### DIFF
--- a/inc/fields/text.php
+++ b/inc/fields/text.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'RWMB_Text_Field' ) )
 				'<input type="text" class="rwmb-text" name="%s" id="%s" value="%s" placeholder="%s" size="%s" %s>%s',
 				$field['field_name'],
 				$field['id'],
-				$meta,
+				esc_attr( $meta ),
 				$field['placeholder'],
 				$field['size'],
 				$field['datalist'] ? "list='{$field['datalist']['id']}'" : '',


### PR DESCRIPTION
Text field values weren't being escaped but somehow this worked out fine for non-cloneable fields. However, with cloneable fields this could become an issue if the text contains a double quote.

Fixes #594