### PR TITLE
Use strict comparisons in select.php file

### DIFF
--- a/inc/fields/select.php
+++ b/inc/fields/select.php
@@ -102,9 +102,9 @@ if ( ! class_exists( 'RWMB_Select_Field' ) )
 			$html = '';
 			if ( $field['placeholder'] )
 			{
-				$show_placeholder = ( 'select' == $field['type'] ) // Normal select field
-					|| ( isset( $field['field_type'] ) && 'select' == $field['field_type'] ) // For 'post' field
-					|| ( isset( $field['display_type'] ) && 'select' == $field['display_type'] ); // For 'taxonomy' field
+				$show_placeholder = ( 'select' === $field['type'] ) // Normal select field
+					|| ( isset( $field['field_type'] ) && 'select' === $field['field_type'] ) // For 'post' field
+					|| ( isset( $field['display_type'] ) && 'select' === $field['display_type'] ); // For 'taxonomy' field
 				$html             = $show_placeholder ? "<option value=''>{$field['placeholder']}</option>" : '<option></option>';
 			}
 


### PR DESCRIPTION
This simply resolves some "Use strict comparisons (=== or !==)" WordPress-Coding-Standards phpcs warnings (WordPress.PHP.StrictComparisons).