### PR TITLE
Use wp_json_encode() instead of json_encode()

### DIFF
--- a/inc/fields/autocomplete.php
+++ b/inc/fields/autocomplete.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'RWMB_Autocomplete_Field' ) )
 						'label' => $label,
 					);
 				}
-				$options = json_encode( $options );
+				$options = wp_json_encode( $options );
 			}
 
 			// Input field that triggers autocomplete.

--- a/inc/fields/date.php
+++ b/inc/fields/date.php
@@ -54,7 +54,7 @@ if ( ! class_exists( 'RWMB_Date_Field' ) )
 				$meta,
 				isset( $field['clone'] ) && $field['clone'] ? '' : $field['id'],
 				$field['size'],
-				esc_attr( json_encode( $field['js_options'] ) )
+				esc_attr( wp_json_encode( $field['js_options'] ) )
 			);
 		}
 

--- a/inc/fields/datetime.php
+++ b/inc/fields/datetime.php
@@ -98,7 +98,7 @@ if ( ! class_exists( 'RWMB_Datetime_Field' ) )
 				isset( $field['timestamp'] ) && $field['timestamp'] ? date( self::translate_format( $field ), $meta ) : $meta,
 				isset( $field['clone'] ) && $field['clone'] ? '' : $field['id'],
 				$field['size'],
-				esc_attr( json_encode( $field['js_options'] ) )
+				esc_attr( wp_json_encode( $field['js_options'] ) )
 			);
 		}
 

--- a/inc/fields/map.php
+++ b/inc/fields/map.php
@@ -144,7 +144,7 @@ if ( ! class_exists( 'RWMB_Map_Field' ) )
 
 			$output = sprintf(
 				'<div class="rwmb-map-canvas" data-map_options="%s" style="width:%s;height:%s"></div>',
-				esc_attr( json_encode( $args ) ),
+				esc_attr( wp_json_encode( $args ) ),
 				esc_attr( $args['width'] ),
 				esc_attr( $args['height'] )
 			);

--- a/inc/fields/plupload-image.php
+++ b/inc/fields/plupload-image.php
@@ -127,7 +127,7 @@ if ( ! class_exists( 'RWMB_Plupload_Image_Field' ) )
 				$field['id'],
 				implode( ' ', $classes ),
 				wp_create_nonce( "rwmb-upload-images_{$field['id']}" ),
-				esc_attr( json_encode( $field['js_options'] ) ),
+				esc_attr( wp_json_encode( $field['js_options'] ) ),
 				$i18n_drop,
 				$i18n_or,
 				$field['id'],

--- a/inc/fields/select-advanced.php
+++ b/inc/fields/select-advanced.php
@@ -39,7 +39,7 @@ if ( ! class_exists( 'RWMB_Select_Advanced_Field' ) )
 				$field['id'],
 				$field['size'],
 				$field['multiple'] ? ' multiple' : '',
-				esc_attr( json_encode( $field['js_options'] ) )
+				esc_attr( wp_json_encode( $field['js_options'] ) )
 			);
 
 			$html .= self::options_html( $field, $meta );

--- a/inc/fields/slider.php
+++ b/inc/fields/slider.php
@@ -38,7 +38,7 @@ if ( ! class_exists( 'RWMB_Slider_Field' ) )
 					<span class="rwmb-slider-value-label">%s<span>%s</span>%s</span>
 					<input type="hidden" name="%s" value="%s" class="rwmb-slider-value">
 				</div>',
-				$field['id'], esc_attr( json_encode( $field['js_options'] ) ),
+				$field['id'], esc_attr( wp_json_encode( $field['js_options'] ) ),
 				$field['prefix'], $meta, $field['suffix'],
 				$field['field_name'], $meta
 			);

--- a/inc/fields/time.php
+++ b/inc/fields/time.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'RWMB_Time_Field' ) )
 				$meta,
 				isset( $field['clone'] ) && $field['clone'] ? '' : $field['id'],
 				$field['size'],
-				esc_attr( json_encode( $field['js_options'] ) )
+				esc_attr( wp_json_encode( $field['js_options'] ) )
 			);
 		}
 

--- a/inc/fields/wysiwyg.php
+++ b/inc/fields/wysiwyg.php
@@ -114,7 +114,7 @@ if ( ! class_exists( 'RWMB_Wysiwyg_Field' ) )
 
 		static function footer_scripts()
 		{
-			echo '<script> var rwmb_cloneable_editors = ' . json_encode( self::$cloneable_editors ) . ';</script>';
+			echo '<script> var rwmb_cloneable_editors = ' . wp_json_encode( self::$cloneable_editors ) . ';</script>';
 		}
 	}
 }


### PR DESCRIPTION
This fixes the "The use of function `json_encode()` is discouraged; use `wp_json_encode()` instead" WordPress-Coding-Standards phpcs warnings (WordPress.PHP.DiscouragedFunctions.DiscouragedWithAlternative).

From what I've seen, `wp_json_encode()` is a drop-in replacement for `json_encode()` in these instances but you may want to test everything before merging this, of course.