### PR TITLE
Changed minimum-stability to stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "description": "Easily create custom meta boxes in WordPress.",
   "homepage": "http://metabox.io",
   "license": "GPL-2.0",
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "authors": [
     {
       "name": "Tran Ngoc Tuan Anh",


### PR DESCRIPTION
The `"minimum-stability": "dev"` option forces all packages that use this project as dependency has the same `minimum-stability` setting.