### PR TITLE
Quickfix'es for $field['attributes'] errors in version 3.7.1

### DIFF
--- a/inc/fields/color.php
+++ b/inc/fields/color.php
@@ -59,9 +59,11 @@ if ( ! class_exists( 'RWMB_Color_Field' ) )
 
 			$field = parent::normalize_field( $field );
 
-			$field['attributes'] = wp_parse_args( $field['attributes'], array(
-				'data-options' => wp_json_encode( $field['js_options'] ),
-			) );
+			if( isset( $field['attributes'] ) ) {
+					$field['attributes'] = wp_parse_args( $field['attributes'], array(
+					'data-options' => wp_json_encode( $field['js_options'] ),
+				) );
+			}
 
 			$field['attributes']['class'] = 'rwmb-color';
 

--- a/inc/fields/date.php
+++ b/inc/fields/date.php
@@ -63,9 +63,11 @@ if ( ! class_exists( 'RWMB_Date_Field' ) )
 				'showButtonPanel' => true,
 			) );
 
-			$field['attributes'] = wp_parse_args( $field['attributes'], array(
-				'data-options' => wp_json_encode( $field['js_options'] ),
-			) );
+			if( isset( $field['attributes'] ) ) {
+				$field['attributes'] = wp_parse_args( $field['attributes'], array(
+					'data-options' => wp_json_encode( $field['js_options'] ),
+				) );
+			}
 
 			$field = parent::normalize_field( $field );
 

--- a/inc/fields/input.php
+++ b/inc/fields/input.php
@@ -49,14 +49,16 @@ if ( ! class_exists( 'RWMB_Input_Field' ) )
 				) );
 			}
 
-			$field['attributes'] = wp_parse_args( $field['attributes'], array(
-				'disabled' => $field['disabled'],
-				'list'     => $field['datalist'] ? $field['datalist']['id'] : false,
-				'readonly' => $field['readonly'],
-				'required' => $field['required'],
-				'name'     => $field['field_name'],
-				'id'       => $field['clone'] ? false : $field['id']
-			) );
+			if( isset( $field['attributes'] ) ) {
+				$field['attributes'] = wp_parse_args( $field['attributes'], array(
+					'disabled' => $field['disabled'],
+					'list'     => $field['datalist'] ? $field['datalist']['id'] : false,
+					'readonly' => $field['readonly'],
+					'required' => $field['required'],
+					'name'     => $field['field_name'],
+					'id'       => $field['clone'] ? false : $field['id']
+				) );
+			}
 
 			return $field;
 		}

--- a/inc/fields/number.php
+++ b/inc/fields/number.php
@@ -26,11 +26,13 @@ if ( ! class_exists( 'RWMB_Number_Field' ) )
 				'max'  => false,
 			) );
 
-			$field['attributes'] = wp_parse_args( $field['attributes'], array(
-				'step' => $field['step'],
-				'max'  => $field['max'],
-				'min'  => $field['min'],
-			) );
+			if( isset( $field['attributes'] ) ) {
+				$field['attributes'] = wp_parse_args( $field['attributes'], array(
+					'step' => $field['step'],
+					'max'  => $field['max'],
+					'min'  => $field['min'],
+				) );
+			}
 
 			$field['attributes']['type']  = 'number';
 			$field['attributes']['class'] = 'rwmb-number';

--- a/inc/fields/text.php
+++ b/inc/fields/text.php
@@ -27,12 +27,14 @@ if ( ! class_exists( 'RWMB_Text_Field' ) )
 				'placeholder' => '',
 			) );
 
-			$field['attributes'] = wp_parse_args( $field['attributes'], array(
-				'size'        => $field['size'],
-				'maxlength'   => $field['maxlength'],
-				'pattern'     => $field['pattern'],
-				'placeholder' => $field['placeholder'],
-			) );
+			if( isset( $field['attributes'] ) ) {
+				$field['attributes'] = wp_parse_args( $field['attributes'], array(
+					'size'        => $field['size'],
+					'maxlength'   => $field['maxlength'],
+					'pattern'     => $field['pattern'],
+					'placeholder' => $field['placeholder'],
+				) );
+			}
 
 			$field['attributes']['type']  = 'text';
 			$field['attributes']['class'] = 'rwmb-text';

--- a/inc/fields/time.php
+++ b/inc/fields/time.php
@@ -64,9 +64,11 @@ if ( ! class_exists( 'RWMB_Time_Field' ) )
 				'timeFormat'      => empty( $field['format'] ) ? 'HH:mm' : $field['format'],
 			) );
 
-			$field['attributes'] = wp_parse_args( $field['attributes'], array(
-				'data-options' => wp_json_encode( $field['js_options'] ),
-			) );
+			if( isset( $field['attributes'] ) ) {
+				$field['attributes'] = wp_parse_args( $field['attributes'], array(
+					'data-options' => wp_json_encode( $field['js_options'] ),
+				) );
+			}
 
 			$field = parent::normalize_field( $field );
 


### PR DESCRIPTION
6 fields where throwing errors on $field['attributes'] wanting to be
parsed when it was empty. This caused the Meida Library to break, not
showing images and not uploading new ones.

Put a quickfix isset check around the lines to have the plugin working
agagin.