### PR TITLE
Please add 'srcset' for images.

### DIFF
--- a/inc/fields/image.php
+++ b/inc/fields/image.php
@@ -236,6 +236,7 @@ if ( ! class_exists( 'RWMB_Image_Field' ) )
 				'caption'     => $attachment->post_excerpt,
 				'description' => $attachment->post_content,
 				'alt'         => get_post_meta( $file_id, '_wp_attachment_image_alt', true ),
+				'srcset'      => wp_get_attachment_image_srcset( $file_id ),
 			);
 		}
 	}


### PR DESCRIPTION
I've added new `srcset` attribute in WP4.4. 

I've tried to add `'sizes' => wp_get_attachment_image_sizes( $file_id ),` but it seems to return default value.