### PR TITLE
Update jquery.ui.datepicker.css

### DIFF
--- a/css/jqueryui/jquery.ui.datepicker.css
+++ b/css/jqueryui/jquery.ui.datepicker.css
@@ -66,3 +66,9 @@
     width: 200px; /*must have*/
     height: 200px; /*must have*/
 }
+
+/* Better Date-picker styles */
+#ui-datepicker-div {
+    background: rgb(35, 40, 45);
+    padding: 1rem;
+}


### PR DESCRIPTION
Default date-picker is a bit odd.
![](https://i.imgur.com/TQsULxW.png)

It can be styled In the file `jquery.ui.datepicker.css` if you add this 

```
#ui-datepicker-div {
    background: rgb(35, 40, 45);
    padding: 1rem;
}

```

At the end.

Which makes it look like this 

![](https://i.imgur.com/V4uHe7s.png)

Which is much better!