### PR TITLE
Fix warning get_value of taxonomy field

### DIFF
--- a/inc/fields/taxonomy.php
+++ b/inc/fields/taxonomy.php
@@ -139,7 +139,7 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field
 		$value = get_the_terms( $post_id, $field['taxonomy'] );
 
 		// Get single value if necessary
-		if ( ! $field['clone'] && ! $field['multiple'] )
+		if ( ! $field['clone'] && ! $field['multiple'] && is_array( $value ) )
 		{
 			$value = reset( $value );
 		}


### PR DESCRIPTION
After updated one of my sites to meta-box 4.8.2 (from 4.7.3), almost everything went smooth.
I only had a warning when retrieving a postmeta of type taxonomy.

> Warning: reset() expects parameter 1 to be array, boolean given in /Users/username/Sites/mysite.local/dev/wp-content/plugins/meta-box/inc/fields/taxonomy.php on line 144

To fix it, an `is_array` conditionnal prevents `$value` to be reset if it's not an array