### PR TITLE
Adds min-width to type `select`

### DIFF
--- a/css/select.css
+++ b/css/select.css
@@ -1,3 +1,6 @@
+.rwmb-select{
+	min-width: 160px;
+}
 .rwmb-select-all-none {
 	display: block;
 	margin-top: 5px;


### PR DESCRIPTION
Min width for type select to match the width of text input.

### Before: 

> ![](https://i.imgur.com/NlG6WYu.png)

### After:

> ![](https://i.imgur.com/aKB7Yxk.png)