### PR TITLE
Refactored meta code

### DIFF
--- a/inc/field.php
+++ b/inc/field.php
@@ -145,6 +145,23 @@ abstract class RWMB_Field
 	}
 
 	/**
+	 * Get raw meta value
+	 *
+	 * @param int   $post_id
+	 * @param array $field
+	 *
+	 * @return mixed
+	 */
+	public static function raw_meta( $post_id, $field )
+	{
+		if ( empty( $field['id'] ) )
+			return '';
+
+		$single = $field['clone'] || ! $field['multiple'];
+		return get_post_meta( $post_id, $field['id'], $single );
+	}
+
+	/**
 	 * Get meta value
 	 *
 	 * @param int   $post_id
@@ -162,8 +179,8 @@ abstract class RWMB_Field
 		if ( empty( $field['id'] ) )
 			return '';
 
-		$single = $field['clone'] || ! $field['multiple'];
-		$meta   = get_post_meta( $post_id, $field['id'], $single );
+		// Get raw meta
+		$meta = self::call( $field, 'raw_meta', $post_id );
 
 		// Use $field['std'] only when the meta box hasn't been saved (i.e. the first time we run)
 		$meta = ! $saved ? $field['std'] : $meta;

--- a/inc/fields/taxonomy-advanced.php
+++ b/inc/fields/taxonomy-advanced.php
@@ -38,41 +38,18 @@ class RWMB_Taxonomy_Advanced_Field extends RWMB_Taxonomy_Field
 	}
 
 	/**
-	 * Standard meta retrieval
+	 * Get raw meta value
 	 *
 	 * @param int   $post_id
-	 * @param bool  $saved
 	 * @param array $field
 	 *
-	 * @return array
+	 * @return mixed
 	 */
-	public static function meta( $post_id, $saved, $field )
+	public static function raw_meta( $post_id, $field )
 	{
 		$meta = get_post_meta( $post_id, $field['id'], true );
 		$meta = wp_parse_id_list( $meta );
-		$meta = array_filter( $meta );
-
-		// Use $field['std'] only when the meta box hasn't been saved (i.e. the first time we run)
-		$meta = ! $saved ? $field['std'] : $meta;
-
-		// Escape attributes
-		$meta = self::call( $field, 'esc_meta', $meta );
-
-		// Make sure meta value is an array for clonable and multiple fields
-		if ( $field['clone'] || $field['multiple'] )
-		{
-			if ( empty( $meta ) || ! is_array( $meta ) )
-			{
-				/**
-				 * Note: if field is clonable, $meta must be an array with values
-				 * so that the foreach loop in self::show() runs properly
-				 * @see self::show()
-				 */
-				$meta = $field['clone'] ? array( '' ) : array();
-			}
-		}
-
-		return $meta;
+		return array_filter( $meta );
 	}
 
 	/**

--- a/inc/fields/taxonomy.php
+++ b/inc/fields/taxonomy.php
@@ -103,41 +103,21 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field
 	}
 
 	/**
-	 * Standard meta retrieval
+	 * Get raw meta value
 	 *
 	 * @param int   $post_id
-	 * @param bool  $saved
 	 * @param array $field
 	 *
-	 * @return array
+	 * @return mixed
 	 */
-	public static function meta( $post_id, $saved, $field )
+	public static function raw_meta( $post_id, $field )
 	{
+		if ( empty( $field['id'] ) )
+			return '';
+
 		$meta = get_the_terms( $post_id, $field['taxonomy'] );
 		$meta = (array) $meta;
-		$meta = wp_list_pluck( $meta, 'term_id' );
-
-		// Use $field['std'] only when the meta box hasn't been saved (i.e. the first time we run)
-		$meta = ! $saved ? $field['std'] : $meta;
-
-		// Escape attributes
-		$meta = self::call( $field, 'esc_meta', $meta );
-
-		// Make sure meta value is an array for clonable and multiple fields
-		if ( $field['clone'] || $field['multiple'] )
-		{
-			if ( empty( $meta ) || ! is_array( $meta ) )
-			{
-				/**
-				 * Note: if field is clonable, $meta must be an array with values
-				 * so that the foreach loop in self::show() runs properly
-				 * @see self::show()
-				 */
-				$meta = $field['clone'] ? array( '' ) : array();
-			}
-		}
-
-		return $meta;
+		return wp_list_pluck( $meta, 'term_id' );
 	}
 
 	/**

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -318,7 +318,7 @@ class RW_Meta_Box
 			{
 				continue;
 			}
-			$value = get_post_meta( $post->ID, $field['id'], ! $field['multiple'] );
+			$value = RWMB_Field::call( $field, 'raw_meta', $post->ID );
 			if (
 				( ! $field['multiple'] && '' !== $value )
 				|| ( $field['multiple'] && array() !== $value )


### PR DESCRIPTION
- Created `raw_meta` function to pull raw meta without formatting
- Use `raw_meta` to replace calls to `get_post_meta`
- Create versions of `raw_meta` for `taxonomy` and `taxonomy_advanced`
to reuse `meta` function

Fixes issue https://github.com/rilwis/meta-box/issues/988 that prevented
meta boxes with only taxonomy fields from being seen as saved.