### PR TITLE
Fixed shorter width of email field VS other fields

### DIFF
--- a/inc/fields/input.php
+++ b/inc/fields/input.php
@@ -26,6 +26,7 @@ abstract class RWMB_Input_Field extends RWMB_Field {
 	public static function normalize( $field ) {
 		$field = parent::normalize( $field );
 		$field = wp_parse_args( $field, array(
+			'size'        => 30,
 			'datalist' => false,
 			'readonly' => false,
 		) );
@@ -53,6 +54,7 @@ abstract class RWMB_Input_Field extends RWMB_Field {
 			'value'       => $value,
 			'placeholder' => $field['placeholder'],
 			'type'        => $field['type'],
+			'size'        => $field['size'],
 		) );
 
 		return $attributes;


### PR DESCRIPTION
Email field appears shorter than other fields ( for example text and url fields ). I tried to fix that in this commit. Please do it in a better way if possible as I am not confident about this improvement.