### PR TITLE
check if RWMB_URL is already defined, don't try to define it twice

### DIFF
--- a/inc/loader.php
+++ b/inc/loader.php
@@ -23,7 +23,9 @@ class RWMB_Loader {
 		list( $path, $url ) = self::get_path( dirname( dirname( __FILE__ ) ) );
 
 		// Plugin URLs, for fast enqueuing scripts and styles.
-		define( 'RWMB_URL', $url );
+		if ( !defined( 'RWMB_URL' ) )
+			define( 'RWMB_URL', $url );
+
 		define( 'RWMB_JS_URL', trailingslashit( RWMB_URL . 'js' ) );
 		define( 'RWMB_CSS_URL', trailingslashit( RWMB_URL . 'css' ) );
 


### PR DESCRIPTION
If meta-box is bundled as part of another plugin, we need to define RWMB_URL to point to the bundled location. I usually do this with code that looks something like below. This example assumes that I bundle meta-box by putting it in a folder called `ext/meta-box` under my main plugin file tree.

    define('MY_PLUGIN_URL',plugins_url('',__FILE__));
    define("RWMB_URL",MY_PLUGIN_URL."/ext/meta-box/");
    require __DIR__."/ext/meta-box/meta-box.php";

This works fine, since the `RWMB_URL` constant is defined before meta-box is loaded and the constant defined inside meta-box will be ignored. However, there will be a warning generated, which is not so clean, and will cause problems e.g. with unit testing.

This pull request adds a check to see if the constant is already defined, and it doesn't define it if that's the case.

Let me know what you think!