### PR TITLE
Correct condition so that the fields are correctly translated.

### DIFF
--- a/inc/wpml.php
+++ b/inc/wpml.php
@@ -53,7 +53,7 @@ class RWMB_WPML {
 		}
 
 		$field = rwmb_get_registry( 'field' )->get( $meta_data['key'], get_post_type( $meta_data['master_post_id'] ) );
-		if ( false !== $field || ! in_array( $field['type'], $this->field_types, true ) ) {
+		if ( false === $field || ! in_array( $field['type'], $this->field_types, true ) ) {
 			return $value;
 		}
 


### PR DESCRIPTION
Correct condition so that the fields based on posts/taxonomies are correctly translated.